### PR TITLE
mobile nav, home page layout cleanup, and styling improvements

### DIFF
--- a/app/views/blog_posts/edit.html.erb
+++ b/app/views/blog_posts/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/navbar" %>
 <div class="m-24">
-  <h1 class="font-Ubuntu text-center text-veryDarkBlue text-2xl md:text-4xl z-10 mt-48">Edit Post</h1>
+  <h1 class="font-Ubuntu text-center text-veryDarkBlue text-2xl md:text-4xl z-10 mt-48 tracking-tight">Edit Post</h1>
   <%= render partial: "form", locals: { blog_post: @blog_post } %>
 </div>

--- a/app/views/blog_posts/index.html.erb
+++ b/app/views/blog_posts/index.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "shared/navbar" %>
 
 <!-- Category band -->
-<div class="relative py-16 mt-32 mb-16">
+<div class="relative py-16 mt-8 md:mt-32 mb-16">
 
   <!-- Background -->
   <div class="absolute inset-0 rounded-bl-[4rem] rounded-tr-[4rem] overflow-hidden">
@@ -88,7 +88,7 @@
 
 <!-- Page heading -->
 <div class="text-center pt-12 pb-10 px-4">
-  <h1 class="font-Ubuntu text-4xl md:text-5xl text-veryDarkBlue">Be Inspired</h1>
+  <h1 class="font-Ubuntu text-4xl md:text-5xl text-veryDarkBlue tracking-tight">Be Inspired</h1>
   <p class="mt-3 font-light text-veryDarkGrayishBlue text-lg">Stories and inspiration from the community</p>
   <div class="mt-6 mx-auto w-16 border-t-2 border-veryLightRed"></div>
 </div>

--- a/app/views/blog_posts/new.html.erb
+++ b/app/views/blog_posts/new.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/navbar"  =%>
 <div class="m-24">
-<h1 class="font-Ubuntu text-center text-veryDarkBlue text-2xl md:text-4xl z-10 mt-48">Share a story</h1>
+<h1 class="font-Ubuntu text-center text-veryDarkBlue text-2xl md:text-4xl z-10 mt-48 tracking-tight">Share a story</h1>
 <%= render partial: "form", locals: {blog_post: @blog_post} %>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,13 +1,10 @@
  <%= render partial: "shared/navbar"  =%>
-<header class="relative text-center">
+<header class="text-center">
   <div style="background-image: var(--background-image-intro-mobile)"
-     class="h-[40rem] rounded-bl-[5rem] bg-left-bottom md:rounded-bl-[13rem] md:bg-top-right bg-no-repeat bg-cover">
-  </div>
-  <div class="absolute inset-x-2 bottom-40">
-    <h1 class=" text-white text-4xl md:text-6xl p-6 mt-12">A modern girls strength training journey
-    </h1>
+     class="h-[40rem] rounded-bl-[5rem] md:rounded-bl-[13rem] bg-no-repeat bg-cover flex flex-col items-center justify-center">
+    <h1 class="text-white text-4xl md:text-6xl px-6 pb-6 tracking-tight">A modern girls strength training journey</h1>
     <p class="pb-3 font-light text-xl text-white/85">Share and Inspire through your fitness journey</p>
-    <div class="md:flex justify-center gap-6 mt-6">
+    <div class="md:flex justify-center gap-6 mt-4">
       <%= button_to blog_posts_all_path, method: :get, class: "btn btn-primary" do %>
         Get Inspired
       <% end %>
@@ -16,12 +13,11 @@
       <% end %>
     </div>
   </div>
-</div>
 </header>
-  <div class="space-y-16 text-center md:text-left mt-24">
+  <div class="text-center md:text-left mt-16 overflow-visible">
     <h2 class="relative z-10 font-Ubuntu m-8 text-center text-veryDarkBlue text-3xl md:text-4xl">Stronger for the Future</h2>
     <!-- Section 1: Intro with text and image -->
-    <div class="grid grid-cols-1 md:grid-cols-[minmax(2rem,1fr)_minmax(0,40rem)_minmax(0,40rem)_minmax(2rem,1fr)] gap-6 px-4 md:px-0 pb-12">
+    <div class="grid grid-cols-1 md:grid-cols-[minmax(2rem,1fr)_minmax(0,40rem)_minmax(0,40rem)_minmax(2rem,1fr)] gap-6 px-4 md:px-0 pt-8 md:pt-0 pb-12 overflow-visible">
       <!-- Left spacer -->
       <div class="hidden md:block"></div>
       <!-- Text content -->
@@ -35,35 +31,36 @@
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </p>
       </div>
-      <!-- Image content - bleeds right to viewport edge, overflows top/bottom -->
-      <div class="row-start-1 md:col-start-3 md:col-span-2 md:-my-16 flex items-center md:h-[520px]">
+      <!-- Image content - bleeds right to viewport edge, overflows bottom only on desktop -->
+      <div class="row-start-1 md:col-start-3 md:col-span-2 md:-mb-16 flex items-center md:h-[520px]">
         <%= image_tag('sitting_girl_desktop.png', class: 'hidden md:block w-4/5 h-full object-cover object-center ml-auto') %>
         <%= image_tag('sitting_girl_mobile.png', class: 'block md:hidden w-2/3 mx-auto') %>
       </div>
     </div>
       <!-- Section 2 -->
-    <div class="grid grid-cols-1 md:grid-cols-[minmax(2rem,1fr)_minmax(0,40rem)_minmax(0,40rem)_minmax(2rem,1fr)] gap-6 relative py-12 my-16">
+    <div class="grid grid-cols-1 md:grid-cols-[minmax(2rem,1fr)_minmax(0,40rem)_minmax(0,40rem)_minmax(2rem,1fr)] gap-6 relative pt-0 pb-12 md:py-12 mt-32 md:mt-16 mb-0">
       <!-- Background layer - height driven by text column -->
       <div class="absolute inset-0 col-span-full rounded-bl-[10rem] rounded-tr-[10rem] overflow-hidden">
         <div class="absolute inset-0 bg-gradient-to-r from-[hsla(237,17%,21%,0.95)] to-[hsla(237,23%,32%,0.95)]"></div>
         <%= image_tag('bg-pattern-circles.svg', class: 'absolute inset-0 w-full h-full object-cover') %>
+        <div class="absolute inset-0 bg-veryDarkGrayBlue/70"></div>
       </div>
-      <!-- Illustration - absolute on desktop so it doesn't drive row height, bleeds top/bottom -->
-      <div class="md:col-start-2 relative z-10">
-        <%= image_tag("illustration-phones.svg", class: 'md:absolute md:bottom-0 md:h-[160%] w-auto object-contain') %>
+      <!-- Illustration - breaks above background on mobile, sits at top of section on desktop -->
+      <div class="md:col-start-2 relative z-10 -mt-24 md:-mt-12 flex justify-center">
+        <%= image_tag("illustration-phones.svg", class: 'h-64 md:h-[32rem] w-auto object-contain') %>
       </div>
       <!-- Text -->
       <div class="md:col-start-3 flex flex-col justify-center text-center md:text-left relative z-10 p-10">
-        <h1 class="mt-0 text-4xl md:mt-12 text-grayishBlue50">Content that reflects reality</h1>
+        <h2 class="text-4xl text-grayishBlue50">Content that reflects reality</h2>
         <p class="text-grayishBlue pt-12 font-light">
           Lore Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
         </p>
       </div>
     </div>
     <!-- Section 3: Free / Powerful -->
-    <div class="grid grid-cols-1 md:grid-cols-[minmax(2rem,1fr)_minmax(0,40rem)_minmax(0,40rem)_minmax(2rem,1fr)] gap-6 md:px-0 pb-12 mt-32">
-      <!-- Image content - bleeds left to viewport edge, overflows top/bottom -->
-      <div class="md:col-start-1 md:col-span-2 md:-my-16 flex items-center md:h-[520px]">
+    <div class="grid grid-cols-1 md:grid-cols-[minmax(2rem,1fr)_minmax(0,40rem)_minmax(0,40rem)_minmax(2rem,1fr)] gap-6 md:px-0 pt-8 md:pt-0 pb-12 mt-16 overflow-visible">
+      <!-- Image content - bleeds left to viewport edge, overflows bottom only on desktop -->
+      <div class="md:col-start-1 md:col-span-2 md:-mb-16 flex items-center md:h-[520px]">
         <%= image_tag('bottom_desktop.png', class: 'hidden md:block w-4/5 h-full object-cover object-center mr-auto') %>
         <%= image_tag('jump_mobile.png', class: 'block md:hidden w-2/3 mx-auto') %>
       </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -4,28 +4,27 @@
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="flex h-16 items-center justify-between">
       
-      <!-- LEFT: Mobile menu button (visible on mobile only) -->
-      <div class="sm:hidden">
+      <!-- Logo (left on mobile, left on desktop) -->
+      <div class="order-1 flex flex-1 justify-start">
+         <%= link_to root_path do %>
+            <% logo = is_home ? "logo.svg" : is_blog_index ? "logo-dark.svg" : "logo-pink.png" %>
+            <%= image_tag(logo, class: is_home ? "h-10" : "h-16") %>
+          <% end %>
+      </div>
+
+      <!-- Mobile menu button (right side, visible on mobile only) -->
+      <div class="sm:hidden order-3">
         <button type="button"
           class="inline-flex items-center justify-center rounded-md p-2
             <%= is_home ? 'text-white' : is_blog_index ? 'text-veryDarkBlue' : 'text-textRed' %>
             focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
           aria-controls="mobile-menu" aria-expanded="false" id="mobile-menu-button">
           <span class="sr-only">Open main menu</span>
-          <!-- Hamburger icon -->
           <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
               d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
           </svg>
         </button>
-      </div>
-
-      <!-- CENTER / RIGHT: Logo (right on mobile, center on desktop) -->
-      <div class="order-2 sm:order-1 flex flex-1 justify-end sm:justify-start">
-         <%= link_to root_path do %>
-            <% logo = is_home ? "logo.svg" : is_blog_index ? "logo-dark.svg" : "logo-pink.png" %>
-            <%= image_tag(logo, class: is_home ? "h-10" : "h-16") %>
-          <% end %>
       </div>
 
       <!-- DESKTOP NAV LINKS + AUTH -->
@@ -54,13 +53,14 @@
             <!-- Dropdown -->
             <div
               id="user-dropdown"
-              class="hidden absolute right-0 top-12 w-48 bg-white rounded-md font-ubuntu text-light z-20"
+              class="hidden absolute right-0 top-12 w-44 bg-white rounded-xl shadow-lg ring-1 ring-black/5 font-ubuntu z-20 overflow-hidden"
             >
-              <%= link_to "Profile", edit_user_registration_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
-              <%= link_to "New Post", new_blog_post_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+              <%= link_to "Profile", edit_user_registration_path, class: "flex items-center gap-2 px-4 py-3 text-sm text-veryDarkGrayishBlue hover:bg-veryLightRed hover:text-textRed transition-colors" %>
+              <%= link_to "New Post", new_blog_post_path, class: "flex items-center gap-2 px-4 py-3 text-sm text-veryDarkGrayishBlue hover:bg-veryLightRed hover:text-textRed transition-colors" %>
+              <div class="border-t border-gray-100"></div>
               <%= link_to "Logout", destroy_user_session_path,
                   method: :delete,
-                  class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+                  class: "flex items-center gap-2 px-4 py-3 text-sm text-textRed hover:bg-veryLightRed transition-colors" %>
             </div>
           </div>
         <% else %>


### PR DESCRIPTION
- Move mobile hamburger to right side of navbar
- Restyle avatar dropdown with site colours and shadow
- Fix home page hero: replace absolute positioning with flexbox, remove stray closing tag
- Clean up home page section spacing: remove space-y-16, explicit margins per section
- Section 2 dark background: match blog_posts route gradient + overlay, phones image breakout
- Fix section 1 & 3 image overflow clipping with overflow-visible
- Reduce image bleed to bottom-only on desktop (md:-mb-16)
- Add tracking-tight to all h1 elements sitewide
- Fix blog_posts/all mobile top spacing